### PR TITLE
fix: apply GitHub App authentication for badge automation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -56,11 +58,20 @@ jobs:
       - name: Run benchmarks
         run: go test -bench=. -benchmem ./...
       
+      # Generate GitHub App token for badge automation
+      - name: Generate GitHub App token
+        if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest' && matrix.go-version == '1.24'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.BADGE_BOT_APP_ID }}
+          private-key: ${{ secrets.BADGE_BOT_PRIVATE_KEY }}
+
       # Generate badge data from CI metrics (only from primary job)
       - name: Generate badge data
         if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest' && matrix.go-version == '1.24'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           mkdir -p .github/badges
           
@@ -137,10 +148,15 @@ jobs:
           
       - name: Commit badges to main branch
         if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest' && matrix.go-version == '1.24'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          # Configure git
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          # Configure git with GitHub App identity and authentication
+          git config --global user.name "Badge Automation Bot"
+          git config --global user.email "action@github.com"
+          
+          # Configure git to use the GitHub App token for authentication
+          git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
           
           # Add badge files to git
           git add .github/badges/
@@ -149,6 +165,6 @@ jobs:
           if git diff --staged --quiet; then
             echo "No badge changes to commit"
           else
-            git commit -m "Update badges from CI run ${{ github.run_number }} [skip ci]"
-            git push origin main
+            git commit -m "chore: update badges from CI run ${{ github.run_number }} [skip ci]"
+            git push origin HEAD:main
           fi


### PR DESCRIPTION
**CRITICAL AUTHENTICATION FIXES**: Applies research-backed solutions for GitHub App badge automation.

## Problem
Badge automation fails with branch protection violations despite GitHub App installation. Current workflow uses standard GITHUB_TOKEN which cannot bypass branch protection rules.

## Solution Applied
1. ✅ **GitHub App token generation** - Uses actions/create-github-app-token@v1
2. ✅ **persist-credentials: false** - Prevents token conflicts (research-backed)
3. ✅ **Git URL rewriting** - Enables proper GitHub App token authentication
4. ✅ **Badge Automation Bot attribution** - Professional commit attribution
5. ✅ **Environment variables** - Standard GitHub Actions pattern

## Research References
- GitHub Community Discussion: https://github.com/orgs/community/discussions/72173
- Stack Overflow: https://stackoverflow.com/questions/77433427/why-do-bypass-settings-in-github-actions-rulesets-not-apply

## Expected Result
After merging this PR and configuring branch protection bypass:
- ✅ Badge automation will work end-to-end
- ✅ Branch protection bypass will function correctly
- ✅ Green status on Actions/Checks will be achieved
- ✅ Professional 'Badge Automation Bot' commit attribution

## Manual Step Required After Merge
Add GitHub App to branch protection bypass (simpler than rulesets):
1. Temporarily disable admin enforcement: `gh api repos/bold-minds/id/branches/main/protection/enforce_admins -X DELETE`
2. OR add GitHub App to branch protection bypass list
3. Test badge automation for green status

**This solution is tested and verified on bold-minds/ex repository with green status achievement.**